### PR TITLE
Make features load upon first navigation to a page

### DIFF
--- a/background.js
+++ b/background.js
@@ -9,3 +9,15 @@ chrome.storage.onChanged.addListener(function(changes, areaName){
         }
     });
 });
+
+chrome.tabs.onUpdated.addListener(
+    function(tabId, changeInfo, tab)
+    {
+        if(changeInfo.url)
+        {
+            chrome.tabs.sendMessage(tabId, {
+                message: 'reload',
+            })
+        }
+    }
+);

--- a/content.js
+++ b/content.js
@@ -49,6 +49,7 @@ function checkURL() {
     addProposeChangesToolTips();
   } else if (
     window.location.href.indexOf('pull') !== NOT_FOUND &&
+    window.location.href.indexOf('pulls') === NOT_FOUND &&
     window.location.href.indexOf('quick_pull') === NOT_FOUND
   ) {
     addReviewPullRequestTips();
@@ -73,7 +74,23 @@ function checkURL() {
   }
 }
 
+chrome.runtime.onMessage.addListener(
+  function(request, sender, sendResponse)
+  {
+    if(request.message === 'reload')
+    {
+      
+        console.log("Reloading...");
+        location.reload();
+      
+    }
+  }
+);
+
 checkURL();
+
+
+
 
 /**
  * Function name: checkIsEditingForkedFile

--- a/manifest.json
+++ b/manifest.json
@@ -19,6 +19,11 @@
       "run_at": "document_end"
     }
   ],
+
+  "background": {
+    "scripts": ["background.js"]
+  },
+
   "web_accessible_resources": ["*.json"],
-  "permissions": ["tabs", "storage"]
+  "permissions": ["https://github.com/*", "tabs", "storage", "webNavigation", "activeTab"]
 }


### PR DESCRIPTION
To make issues appear when navigating, the plugin now detects when the url changes, and reloads the page to ensure all elements load properly
Addresses Issues #23 and #21 