### PR TITLE
fixed overlapping text in commit message box

### DIFF
--- a/content.js
+++ b/content.js
@@ -7,6 +7,7 @@ class ToolTipIcon {
     this.toolTipText = toolTipText;
     this.gitHubElement = gitHubElement;
   }
+  
 
   createIcon() {
     const toolTipContainer = document.createElement('div');
@@ -19,6 +20,7 @@ class ToolTipIcon {
     const toolTip = document.createElement('span');
     toolTip.className = 'helpIconText';
     toolTip.innerHTML = this.toolTipText;
+    
 
     toolTipContainer.appendChild(circleIcon);
     toolTipContainer.appendChild(toolTip);
@@ -304,6 +306,7 @@ function addProposeChangesToolTips() {
     'placeholder',
     'You can add a more detailed description here if needed.'
   );
+  document.getElementsByClassName("CommentBox-placeholder")[0].innerHTML = ""
 
   try {
     var branchName = document.getElementsByClassName('branch-name')[0].innerText;


### PR DESCRIPTION
Fixed an issue where placeholder text overlapped with other text.

Before
![image](https://github.com/RESHAPELab/ResearchPlugin/assets/46322024/cfaefbd4-ac44-49ca-ad07-2aa698c82e8e)

After

![image](https://github.com/wacker22/ResearchPlugin/assets/46322024/9525e66a-141e-4cd3-b0bd-dd4c33d5f593)
